### PR TITLE
Avoid sqrt(x:Float) return NaN in HashLink build

### DIFF
--- a/Sources/oimo/common/MathUtil.hx
+++ b/Sources/oimo/common/MathUtil.hx
@@ -120,7 +120,8 @@ class MathUtil {
 	 * Returns `Math.sqrt(x)`.
 	 */
 	public static inline function sqrt(x:Float):Float {
-		return Math.sqrt(x);
+		return x >= 0.0 ? Math.sqrt(x) : 0.0;
+		// return Math.sqrt(x);
 	}
 
 	/**


### PR DESCRIPTION
In HashLink build, there is chance that the input of fuction sqrt(x:Float) is a very small negative value (which actually should be zero). This will cause some physics collision detections fail to work.
This Fix is trying to address this issue.